### PR TITLE
[READY] minor GHA fixes

### DIFF
--- a/.github/workflows/check_images.yml
+++ b/.github/workflows/check_images.yml
@@ -10,7 +10,7 @@ jobs:
     name: check images
     runs-on: ubuntu-latest
     container:
-      image: perl:5
+      image: perl@sha256:1ec7df9b6c70e31b05d937f929ddfe06a6a1966d98c09ae78ecfbb391a364739
     steps:
       - name: checkout
         id: checkout

--- a/.github/workflows/check_images.yml
+++ b/.github/workflows/check_images.yml
@@ -1,7 +1,8 @@
 ---
-name: ansible-test
+name: check images
 
 on:
+  pull_request:
   push:   # runs on every push
   workflow_dispatch:
 


### PR DESCRIPTION
## Description of PR
Pins the GHA perl container by sha256

## Previous Behavior
using `perl:5` for Github Actions

## New Behavior
using `perl@sha256:1ec7df9b6c70e31b05d937f929ddfe06a6a1966d98c09ae78ecfbb391a364739` for Github Actions

## Tests
`docker run -ti perl@sha256:1ec7df9b6c70e31b05d937f929ddfe06a6a1966d98c09ae78ecfbb391a364739 bash`
verified it works, also it's just a copy from `scale-network`
