### PR TITLE
[READY] update docker build to add platform targeting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,13 @@ DOCKERCMD = docker
 # TODO: dockerhub for scale eventually
 DOCKERREPO = sarcasticadmin
 IMAGENAME ?= scale-signs
-DOCKERBUILD = $(DOCKERCMD) build
+TARGETPLATFORM ?= "linux/amd64"
+DOCKERBUILD = $(DOCKERCMD) buildx build
 
 DOCKERVERSION ?= $(shell git rev-parse --short HEAD)
 
 docker-build:
-	$(DOCKERBUILD) -t "$(DOCKERREPO)/$(IMAGENAME):$(DOCKERVERSION)" .
+	$(DOCKERBUILD) --platform $(TARGETPLATFORM) -t "$(DOCKERREPO)/$(IMAGENAME):$(DOCKERVERSION)" .
 
 docker-push: docker-build
 	$(DOCKERCMD) push "$(DOCKERREPO)/$(IMAGENAME):$(DOCKERVERSION)"


### PR DESCRIPTION
## Description of PR
Add platform targeting for docker builds

## Previous Behavior
- Docker build used OS platform/arch by default

## New Behavior
- Docker builds defaults to `linux/amd64` by default and is configurable through `TARGETPLATFORM` var

## Tests
- Built from a darwin/arm system and verified via docker inspect
- Uploaded to docker hub and verified platform [here](https://hub.docker.com/layers/sarcasticadmin/scale-signs/1a4fbab/images/sha256-513db48ac4aeab69426871d1d6f9d6c41931c7978b8cb117c230078c2e82560f?context=explore)
