### PR TITLE
[READY] update Dockerfile to use alternative CentOS mirror, vault

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
 FROM centos:7
+# CentOS is EOL https://www.redhat.com/en/blog/centos-linux-vs-rhel
+# mirrorlist no longer available
+# https://kb.filewave.com/books/linux-tips-and-tricks/page/updating-centos-repo-files-after-mirrorlist-end-of-life
+# Alternative is to use vault.centos.org and switch from mirrorlist to baseurl
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && \
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN yum update -y && yum install -y httpd php
 RUN rm /etc/localtime -f && ln -s /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 COPY ["./conf/httpd.conf", "/etc/httpd/conf/httpd.conf"]


### PR DESCRIPTION
## Description of PR
@carlynlee reported the following issue when attempting to run the sign server locally. Looks like after RH EOL'd CentOS the DNS name mirrorlist.centos.org no longer works. Luckily there is a repo up at vault.centos.org that we can use.

```
=> ERROR [signs 2/6] RUN yum update -y && yum install -y httpd php             7.6s
------                                                                               
 > [signs 2/6] RUN yum update -y && yum install -y httpd php:                        
1.405 Loaded plugins: fastestmirror, ovl                                             
2.591 Determining fastest mirrors                                                    
3.102 Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was                                                 
3.102 14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"
3.109 
3.109 
3.109  One of the configured repositories failed (Unknown),
3.109  and yum doesn't have enough cached data to continue. At this point the only
3.109  safe thing yum can do is fail. There are a few ways to work "fix" this:
3.109 
3.109      1. Contact the upstream for the repository and get them to fix the problem.
3.109 
3.109      2. Reconfigure the baseurl/etc. for the repository, to point to a working
3.109         upstream. This is most often useful if you are using a newer
3.109         distribution release than is supported by the repository (and the
3.109         packages for the previous distribution release still work).
3.109 
3.109      3. Run the command with the repository temporarily disabled
3.109             yum --disablerepo=<repoid> ...
3.109 
3.109      4. Disable the repository permanently, so yum won't use it by default. Yum
3.109         will then just ignore the repository until you permanently enable it
3.109         again or use --enablerepo for temporary usage:
3.109 
3.109             yum-config-manager --disable <repoid>
3.109         or
3.109             subscription-manager repos --disable=<repoid>
3.109 
3.109      5. Configure the failing repository to be skipped, if it is unavailable.
3.109         Note that yum will try to contact the repo. when it runs most commands,
3.109         so will have to try and fail each time (and thus. yum will be be much
3.109         slower). If it is a very temporary problem though, this is often a nice
3.109         compromise:
3.109 
3.109             yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true
3.109 
3.109 Cannot find a valid baseurl for repo: base/7/x86_64
------
failed to solve: process "/bin/sh -c yum update -y && yum install -y httpd php" did not complete successfully: exit code: 1

```

## Previous Behavior
- yum no longer working in Signs container

## New Behavior
- yum working in Signs container

## Tests
1. build image
```
kylerisse@watson ~/g/s/g/k/scale-signs (centos_eol)> podman rmi -f (podman images -aq)
Untagged: localhost/sarcasticadmin/scale-signs:a325fba
Untagged: localhost/signs:latest
Untagged: docker.io/library/centos:7
Deleted: 611254af0bdc75cd83ee19bf99576a60dc328323eb0029f99cc9ac828f80dfac
Deleted: aaf5b0d36ff7afe0d4061c448b499d56b18806b6cc3ad282bf2e5f270ce17b0f
Deleted: cf2a60e280be070657d95bb124ab325910ae22558554dae69f0f6f5fe1df77a2
Deleted: 8d5821a550bd0359c2a8e10534fd1c32754c20319c3d694e8a0aa56018ff6cf9
Deleted: 514a382a52986eb176a1d55629a562b2c50b20d6c1ffc384c0395e67ddb96713
Deleted: eeb6ee3f44bd0b5103bb561b4c16bcb82328cfe5809ab675bb17ab3a16c517c9
kylerisse@watson ~/g/s/g/k/scale-signs (centos_eol)> DOCKERCMD=podman make docker-build
podman buildx build --platform "linux/amd64" -t "sarcasticadmin/scale-signs:a325fba" .
STEP 1/9: FROM centos:7
Resolved "centos" as an alias (/home/kylerisse/.cache/containers/short-name-aliases.conf)
Trying to pull docker.io/library/centos:7...
Getting image source signatures
Copying blob 2d473b07cdd5 done   | 
Copying config eeb6ee3f44 done   | 
Writing manifest to image destination
STEP 2/9: RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo &&     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo &&     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo &&     sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* &&     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
--> b74e2524b310
STEP 3/9: RUN yum update -y && yum install -y httpd php
Loaded plugins: fastestmirror, ovl
Determining fastest mirrors
Resolving Dependencies
--> Running transaction check
---> Package bash.x86_64 0:4.2.46-34.el7 will be updated
---> Package bash.x86_64 0:4.2.46-35.el7_9 will be an update
---> Package bind-license.noarch 32:9.11.4-26.P2.el7 will be updated
---> Package bind-license.noarch 32:9.11.4-26.P2.el7_9.16 will be an update
---> Package binutils.x86_64 0:2.27-44.base.el7 will be updated
---> Package binutils.x86_64 0:2.27-44.base.el7_9.1 will be an update
---> Package ca-certificates.noarch 0:2020.2.41-70.0.el7_8 will be updated
---> Package ca-certificates.noarch 0:2023.2.60_v7.0.306-72.el7_9 will be an update
---> Package centos-release.x86_64 0:7-9.2009.0.el7.centos will be updated
---> Package centos-release.x86_64 0:7-9.2009.2.el7.centos will be an update
---> Package coreutils.x86_64 0:8.22-24.el7 will be updated
---> Package coreutils.x86_64 0:8.22-24.el7_9.2 will be an update
---> Package curl.x86_64 0:7.29.0-59.el7 will be updated
---> Package curl.x86_64 0:7.29.0-59.el7_9.2 will be an update
---> Package cyrus-sasl-lib.x86_64 0:2.1.26-23.el7 will be updated
---> Package cyrus-sasl-lib.x86_64 0:2.1.26-24.el7_9 will be an update
---> Package device-mapper.x86_64 7:1.02.170-6.el7 will be updated
---> Package device-mapper.x86_64 7:1.02.170-6.el7_9.5 will be an update
---> Package device-mapper-libs.x86_64 7:1.02.170-6.el7 will be updated
---> Package device-mapper-libs.x86_64 7:1.02.170-6.el7_9.5 will be an update
---> Package diffutils.x86_64 0:3.3-5.el7 will be updated
---> Package diffutils.x86_64 0:3.3-6.el7_9 will be an update
---> Package expat.x86_64 0:2.1.0-12.el7 will be updated
---> Package expat.x86_64 0:2.1.0-15.el7_9 will be an update
---> Package geoipupdate.x86_64 0:2.5.0-1.el7 will be updated
---> Package geoipupdate.x86_64 0:2.5.0-2.el7 will be an update
---> Package glib2.x86_64 0:2.56.1-7.el7 will be updated
---> Package glib2.x86_64 0:2.56.1-9.el7_9 will be an update
---> Package glibc.x86_64 0:2.17-317.el7 will be updated
---> Package glibc.x86_64 0:2.17-326.el7_9.3 will be an update
---> Package glibc-common.x86_64 0:2.17-317.el7 will be updated
---> Package glibc-common.x86_64 0:2.17-326.el7_9.3 will be an update
---> Package gzip.x86_64 0:1.5-10.el7 will be updated
---> Package gzip.x86_64 0:1.5-11.el7_9 will be an update
---> Package kpartx.x86_64 0:0.4.9-133.el7 will be updated
---> Package kpartx.x86_64 0:0.4.9-136.el7_9 will be an update
---> Package krb5-libs.x86_64 0:1.15.1-50.el7 will be updated
---> Package krb5-libs.x86_64 0:1.15.1-55.el7_9 will be an update
---> Package libblkid.x86_64 0:2.23.2-65.el7 will be updated
---> Package libblkid.x86_64 0:2.23.2-65.el7_9.1 will be an update
---> Package libcurl.x86_64 0:7.29.0-59.el7 will be updated
---> Package libcurl.x86_64 0:7.29.0-59.el7_9.2 will be an update
---> Package libmount.x86_64 0:2.23.2-65.el7 will be updated
---> Package libmount.x86_64 0:2.23.2-65.el7_9.1 will be an update
---> Package libsmartcols.x86_64 0:2.23.2-65.el7 will be updated
---> Package libsmartcols.x86_64 0:2.23.2-65.el7_9.1 will be an update
---> Package libssh2.x86_64 0:1.8.0-4.el7 will be updated
---> Package libssh2.x86_64 0:1.8.0-4.el7_9.1 will be an update
---> Package libuuid.x86_64 0:2.23.2-65.el7 will be updated
---> Package libuuid.x86_64 0:2.23.2-65.el7_9.1 will be an update
---> Package libxml2.x86_64 0:2.9.1-6.el7.5 will be updated
---> Package libxml2.x86_64 0:2.9.1-6.el7_9.6 will be an update
---> Package libxml2-python.x86_64 0:2.9.1-6.el7.5 will be updated
---> Package libxml2-python.x86_64 0:2.9.1-6.el7_9.6 will be an update
---> Package nspr.x86_64 0:4.25.0-2.el7_9 will be updated
---> Package nspr.x86_64 0:4.35.0-1.el7_9 will be an update
---> Package nss.x86_64 0:3.53.1-3.el7_9 will be updated
---> Package nss.x86_64 0:3.90.0-2.el7_9 will be an update
---> Package nss-pem.x86_64 0:1.0.3-7.el7 will be updated
---> Package nss-pem.x86_64 0:1.0.3-7.el7_9.1 will be an update
---> Package nss-softokn.x86_64 0:3.53.1-6.el7_9 will be updated
---> Package nss-softokn.x86_64 0:3.90.0-6.el7_9 will be an update
---> Package nss-softokn-freebl.x86_64 0:3.53.1-6.el7_9 will be updated
---> Package nss-softokn-freebl.x86_64 0:3.90.0-6.el7_9 will be an update
---> Package nss-sysinit.x86_64 0:3.53.1-3.el7_9 will be updated
---> Package nss-sysinit.x86_64 0:3.90.0-2.el7_9 will be an update
---> Package nss-tools.x86_64 0:3.53.1-3.el7_9 will be updated
---> Package nss-tools.x86_64 0:3.90.0-2.el7_9 will be an update
---> Package nss-util.x86_64 0:3.53.1-1.el7_9 will be updated
---> Package nss-util.x86_64 0:3.90.0-1.el7_9 will be an update
---> Package openldap.x86_64 0:2.4.44-22.el7 will be updated
---> Package openldap.x86_64 0:2.4.44-25.el7_9 will be an update
---> Package openssl-libs.x86_64 1:1.0.2k-19.el7 will be updated
---> Package openssl-libs.x86_64 1:1.0.2k-26.el7_9 will be an update
---> Package python.x86_64 0:2.7.5-89.el7 will be updated
---> Package python.x86_64 0:2.7.5-94.el7_9 will be an update
---> Package python-libs.x86_64 0:2.7.5-89.el7 will be updated
---> Package python-libs.x86_64 0:2.7.5-94.el7_9 will be an update
---> Package rpm.x86_64 0:4.11.3-45.el7 will be updated
---> Package rpm.x86_64 0:4.11.3-48.el7_9 will be an update
---> Package rpm-build-libs.x86_64 0:4.11.3-45.el7 will be updated
---> Package rpm-build-libs.x86_64 0:4.11.3-48.el7_9 will be an update
---> Package rpm-libs.x86_64 0:4.11.3-45.el7 will be updated
---> Package rpm-libs.x86_64 0:4.11.3-48.el7_9 will be an update
---> Package rpm-python.x86_64 0:4.11.3-45.el7 will be updated
---> Package rpm-python.x86_64 0:4.11.3-48.el7_9 will be an update
---> Package systemd.x86_64 0:219-78.el7 will be updated
---> Package systemd.x86_64 0:219-78.el7_9.9 will be an update
---> Package systemd-libs.x86_64 0:219-78.el7 will be updated
---> Package systemd-libs.x86_64 0:219-78.el7_9.9 will be an update
---> Package tzdata.noarch 0:2020d-2.el7 will be updated
---> Package tzdata.noarch 0:2024a-1.el7 will be an update
---> Package util-linux.x86_64 0:2.23.2-65.el7 will be updated
---> Package util-linux.x86_64 0:2.23.2-65.el7_9.1 will be an update
---> Package vim-minimal.x86_64 2:7.4.629-7.el7 will be updated
---> Package vim-minimal.x86_64 2:7.4.629-8.el7_9 will be an update
---> Package xz.x86_64 0:5.2.2-1.el7 will be updated
---> Package xz.x86_64 0:5.2.2-2.el7_9 will be an update
---> Package xz-libs.x86_64 0:5.2.2-1.el7 will be updated
---> Package xz-libs.x86_64 0:5.2.2-2.el7_9 will be an update
---> Package zlib.x86_64 0:1.2.7-18.el7 will be updated
---> Package zlib.x86_64 0:1.2.7-21.el7_9 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package              Arch     Version                          Repository
                                                                           Size
================================================================================
Updating:
 bash                 x86_64   4.2.46-35.el7_9                  updates   1.0 M
 bind-license         noarch   32:9.11.4-26.P2.el7_9.16         updates    92 k
 binutils             x86_64   2.27-44.base.el7_9.1             updates   5.9 M
 ca-certificates      noarch   2023.2.60_v7.0.306-72.el7_9      updates   923 k
 centos-release       x86_64   7-9.2009.2.el7.centos            updates    27 k
 coreutils            x86_64   8.22-24.el7_9.2                  updates   3.3 M
 curl                 x86_64   7.29.0-59.el7_9.2                updates   271 k
 cyrus-sasl-lib       x86_64   2.1.26-24.el7_9                  updates   156 k
 device-mapper        x86_64   7:1.02.170-6.el7_9.5             updates   297 k
 device-mapper-libs   x86_64   7:1.02.170-6.el7_9.5             updates   325 k
 diffutils            x86_64   3.3-6.el7_9                      updates   322 k
 expat                x86_64   2.1.0-15.el7_9                   updates    83 k
 geoipupdate          x86_64   2.5.0-2.el7                      updates    35 k
 glib2                x86_64   2.56.1-9.el7_9                   updates   2.5 M
 glibc                x86_64   2.17-326.el7_9.3                 updates   3.6 M
 glibc-common         x86_64   2.17-326.el7_9.3                 updates    12 M
 gzip                 x86_64   1.5-11.el7_9                     updates   130 k
 kpartx               x86_64   0.4.9-136.el7_9                  updates    81 k
 krb5-libs            x86_64   1.15.1-55.el7_9                  updates   810 k
 libblkid             x86_64   2.23.2-65.el7_9.1                updates   183 k
 libcurl              x86_64   7.29.0-59.el7_9.2                updates   223 k
 libmount             x86_64   2.23.2-65.el7_9.1                updates   185 k
 libsmartcols         x86_64   2.23.2-65.el7_9.1                updates   143 k
 libssh2              x86_64   1.8.0-4.el7_9.1                  updates    88 k
 libuuid              x86_64   2.23.2-65.el7_9.1                updates    84 k
 libxml2              x86_64   2.9.1-6.el7_9.6                  updates   668 k
 libxml2-python       x86_64   2.9.1-6.el7_9.6                  updates   247 k
 nspr                 x86_64   4.35.0-1.el7_9                   updates   128 k
 nss                  x86_64   3.90.0-2.el7_9                   updates   905 k
 nss-pem              x86_64   1.0.3-7.el7_9.1                  updates    75 k
 nss-softokn          x86_64   3.90.0-6.el7_9                   updates   383 k
 nss-softokn-freebl   x86_64   3.90.0-6.el7_9                   updates   321 k
 nss-sysinit          x86_64   3.90.0-2.el7_9                   updates    67 k
 nss-tools            x86_64   3.90.0-2.el7_9                   updates   557 k
 nss-util             x86_64   3.90.0-1.el7_9                   updates    80 k
 openldap             x86_64   2.4.44-25.el7_9                  updates   356 k
 openssl-libs         x86_64   1:1.0.2k-26.el7_9                updates   1.2 M
 python               x86_64   2.7.5-94.el7_9                   updates    97 k
 python-libs          x86_64   2.7.5-94.el7_9                   updates   5.6 M
 rpm                  x86_64   4.11.3-48.el7_9                  updates   1.2 M
 rpm-build-libs       x86_64   4.11.3-48.el7_9                  updates   108 k
 rpm-libs             x86_64   4.11.3-48.el7_9                  updates   279 k
 rpm-python           x86_64   4.11.3-48.el7_9                  updates    84 k
 systemd              x86_64   219-78.el7_9.9                   updates   5.1 M
 systemd-libs         x86_64   219-78.el7_9.9                   updates   419 k
 tzdata               noarch   2024a-1.el7                      updates   497 k
 util-linux           x86_64   2.23.2-65.el7_9.1                updates   2.0 M
 vim-minimal          x86_64   2:7.4.629-8.el7_9                updates   443 k
 xz                   x86_64   5.2.2-2.el7_9                    updates   229 k
 xz-libs              x86_64   5.2.2-2.el7_9                    updates   103 k
 zlib                 x86_64   1.2.7-21.el7_9                   updates    90 k

Transaction Summary
================================================================================
Upgrade  51 Packages

Total download size: 53 M
Downloading packages:
Delta RPMs disabled because /usr/bin/applydeltarpm not installed.
warning: /var/cache/yum/x86_64/7/updates/packages/bash-4.2.46-35.el7_9.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID f4a80eb5: NOKEY
Public key for bash-4.2.46-35.el7_9.x86_64.rpm is not installed
--------------------------------------------------------------------------------
Total                                               35 MB/s |  53 MB  00:01     
Retrieving key from file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
Importing GPG key 0xF4A80EB5:
 Userid     : "CentOS-7 Key (CentOS 7 Official Signing Key) <security@centos.org>"
 Fingerprint: 6341 ab27 53d7 8a78 a7c2 7bb1 24c6 a8a7 f4a8 0eb5
 Package    : centos-release-7-9.2009.0.el7.centos.x86_64 (@CentOS)
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Updating   : centos-release-7-9.2009.2.el7.centos.x86_64                1/102 
  Updating   : tzdata-2024a-1.el7.noarch                                  2/102 
  Updating   : bash-4.2.46-35.el7_9.x86_64                                3/102 
  Updating   : nss-softokn-freebl-3.90.0-6.el7_9.x86_64                   4/102 
  Updating   : glibc-common-2.17-326.el7_9.3.x86_64                       5/102 
  Updating   : glibc-2.17-326.el7_9.3.x86_64                              6/102 
  Updating   : nspr-4.35.0-1.el7_9.x86_64                                 7/102 
  Updating   : nss-util-3.90.0-1.el7_9.x86_64                             8/102 
  Updating   : zlib-1.2.7-21.el7_9.x86_64                                 9/102 
  Updating   : xz-libs-5.2.2-2.el7_9.x86_64                              10/102 
  Updating   : systemd-libs-219-78.el7_9.9.x86_64                        11/102 
  Updating   : libuuid-2.23.2-65.el7_9.1.x86_64                          12/102 
  Updating   : nss-softokn-3.90.0-6.el7_9.x86_64                         13/102 
  Updating   : libxml2-2.9.1-6.el7_9.6.x86_64                            14/102 
  Updating   : libsmartcols-2.23.2-65.el7_9.1.x86_64                     15/102 
  Updating   : diffutils-3.3-6.el7_9.x86_64                              16/102 
install-info: No such file or directory for /usr/share/info/diffutils.info
  Updating   : expat-2.1.0-15.el7_9.x86_64                               17/102 
  Updating   : ca-certificates-2023.2.60_v7.0.306-72.el7_9.noarch        18/102 
  Updating   : 1:openssl-libs-1.0.2k-26.el7_9.x86_64                     19/102 
  Updating   : coreutils-8.22-24.el7_9.2.x86_64                          20/102 
  Updating   : krb5-libs-1.15.1-55.el7_9.x86_64                          21/102 
  Updating   : libblkid-2.23.2-65.el7_9.1.x86_64                         22/102 
  Updating   : libmount-2.23.2-65.el7_9.1.x86_64                         23/102 
  Updating   : python-libs-2.7.5-94.el7_9.x86_64                         24/102 
  Updating   : python-2.7.5-94.el7_9.x86_64                              25/102 
  Updating   : util-linux-2.23.2-65.el7_9.1.x86_64                       26/102 
  Updating   : cyrus-sasl-lib-2.1.26-24.el7_9.x86_64                     27/102 
  Updating   : nss-pem-1.0.3-7.el7_9.1.x86_64                            28/102 
  Updating   : nss-sysinit-3.90.0-2.el7_9.x86_64                         29/102 
  Updating   : nss-3.90.0-2.el7_9.x86_64                                 30/102 
  Updating   : nss-tools-3.90.0-2.el7_9.x86_64                           31/102 
  Updating   : libssh2-1.8.0-4.el7_9.1.x86_64                            32/102 
  Updating   : libcurl-7.29.0-59.el7_9.2.x86_64                          33/102 
  Updating   : curl-7.29.0-59.el7_9.2.x86_64                             34/102 
  Updating   : rpm-libs-4.11.3-48.el7_9.x86_64                           35/102 
  Updating   : rpm-4.11.3-48.el7_9.x86_64                                36/102 
  Updating   : openldap-2.4.44-25.el7_9.x86_64                           37/102 
  Updating   : rpm-build-libs-4.11.3-48.el7_9.x86_64                     38/102 
  Updating   : systemd-219-78.el7_9.9.x86_64                             39/102 
Failed to get D-Bus connection: Operation not permitted
  Updating   : 7:device-mapper-libs-1.02.170-6.el7_9.5.x86_64            40/102 
  Updating   : 7:device-mapper-1.02.170-6.el7_9.5.x86_64                 41/102 
  Updating   : kpartx-0.4.9-136.el7_9.x86_64                             42/102 
  Updating   : rpm-python-4.11.3-48.el7_9.x86_64                         43/102 
  Updating   : geoipupdate-2.5.0-2.el7.x86_64                            44/102 
  Updating   : libxml2-python-2.9.1-6.el7_9.6.x86_64                     45/102 
  Updating   : glib2-2.56.1-9.el7_9.x86_64                               46/102 
  Updating   : binutils-2.27-44.base.el7_9.1.x86_64                      47/102 
install-info: No such file or directory for /usr/share/info/as.info.gz
install-info: No such file or directory for /usr/share/info/binutils.info.gz
install-info: No such file or directory for /usr/share/info/gprof.info.gz
install-info: No such file or directory for /usr/share/info/ld.info.gz
install-info: No such file or directory for /usr/share/info/standards.info.gz
  Updating   : gzip-1.5-11.el7_9.x86_64                                  48/102 
  Updating   : xz-5.2.2-2.el7_9.x86_64                                   49/102 
  Updating   : 2:vim-minimal-7.4.629-8.el7_9.x86_64                      50/102 
  Updating   : 32:bind-license-9.11.4-26.P2.el7_9.16.noarch              51/102 
  Cleanup    : rpm-python-4.11.3-45.el7.x86_64                           52/102 
  Cleanup    : libxml2-python-2.9.1-6.el7.5.x86_64                       53/102 
  Cleanup    : rpm-build-libs-4.11.3-45.el7.x86_64                       54/102 
  Cleanup    : glib2-2.56.1-7.el7.x86_64                                 55/102 
  Cleanup    : python-2.7.5-89.el7.x86_64                                56/102 
  Cleanup    : python-libs-2.7.5-89.el7.x86_64                           57/102 
  Cleanup    : libxml2-2.9.1-6.el7.5.x86_64                              58/102 
  Cleanup    : xz-5.2.2-1.el7.x86_64                                     59/102 
  Cleanup    : binutils-2.27-44.base.el7.x86_64                          60/102 
  Cleanup    : geoipupdate-2.5.0-1.el7.x86_64                            61/102 
  Cleanup    : gzip-1.5-10.el7.x86_64                                    62/102 
  Cleanup    : kpartx-0.4.9-133.el7.x86_64                               63/102 
  Cleanup    : 7:device-mapper-libs-1.02.170-6.el7.x86_64                64/102 
  Cleanup    : 7:device-mapper-1.02.170-6.el7.x86_64                     65/102 
  Cleanup    : systemd-219-78.el7.x86_64                                 66/102 
  Cleanup    : curl-7.29.0-59.el7.x86_64                                 67/102 
  Cleanup    : libcurl-7.29.0-59.el7.x86_64                              68/102 
  Cleanup    : openldap-2.4.44-22.el7.x86_64                             69/102 
  Cleanup    : rpm-libs-4.11.3-45.el7.x86_64                             70/102 
  Cleanup    : rpm-4.11.3-45.el7.x86_64                                  71/102 
  Cleanup    : util-linux-2.23.2-65.el7.x86_64                           72/102 
  Cleanup    : nss-tools-3.53.1-3.el7_9.x86_64                           73/102 
  Cleanup    : nss-sysinit-3.53.1-3.el7_9.x86_64                         74/102 
  Cleanup    : nss-3.53.1-3.el7_9.x86_64                                 75/102 
  Cleanup    : nss-pem-1.0.3-7.el7.x86_64                                76/102 
  Cleanup    : nss-softokn-3.53.1-6.el7_9.x86_64                         77/102 
  Cleanup    : libmount-2.23.2-65.el7.x86_64                             78/102 
  Cleanup    : libblkid-2.23.2-65.el7.x86_64                             79/102 
  Cleanup    : libssh2-1.8.0-4.el7.x86_64                                80/102 
  Cleanup    : systemd-libs-219-78.el7.x86_64                            81/102 
  Cleanup    : cyrus-sasl-lib-2.1.26-23.el7.x86_64                       82/102 
  Cleanup    : krb5-libs-1.15.1-50.el7.x86_64                            83/102 
  Cleanup    : coreutils-8.22-24.el7.x86_64                              84/102 
  Cleanup    : 1:openssl-libs-1.0.2k-19.el7.x86_64                       85/102 
  Cleanup    : diffutils-3.3-5.el7.x86_64                                86/102 
  Cleanup    : ca-certificates-2020.2.41-70.0.el7_8.noarch               87/102 
  Cleanup    : zlib-1.2.7-18.el7.x86_64                                  88/102 
  Cleanup    : xz-libs-5.2.2-1.el7.x86_64                                89/102 
  Cleanup    : libuuid-2.23.2-65.el7.x86_64                              90/102 
  Cleanup    : libsmartcols-2.23.2-65.el7.x86_64                         91/102 
  Cleanup    : expat-2.1.0-12.el7.x86_64                                 92/102 
  Cleanup    : 2:vim-minimal-7.4.629-7.el7.x86_64                        93/102 
  Cleanup    : centos-release-7-9.2009.0.el7.centos.x86_64               94/102 
  Cleanup    : 32:bind-license-9.11.4-26.P2.el7.noarch                   95/102 
  Cleanup    : glibc-common-2.17-317.el7.x86_64                          96/102 
  Cleanup    : bash-4.2.46-34.el7.x86_64                                 97/102 
  Cleanup    : nspr-4.25.0-2.el7_9.x86_64                                98/102 
  Cleanup    : nss-util-3.53.1-1.el7_9.x86_64                            99/102 
  Cleanup    : nss-softokn-freebl-3.53.1-6.el7_9.x86_64                 100/102 
  Cleanup    : glibc-2.17-317.el7.x86_64                                101/102 
  Cleanup    : tzdata-2020d-2.el7.noarch                                102/102 
  Verifying  : libblkid-2.23.2-65.el7_9.1.x86_64                          1/102 
  Verifying  : libcurl-7.29.0-59.el7_9.2.x86_64                           2/102 
  Verifying  : libsmartcols-2.23.2-65.el7_9.1.x86_64                      3/102 
  Verifying  : glibc-common-2.17-326.el7_9.3.x86_64                       4/102 
  Verifying  : nss-softokn-3.90.0-6.el7_9.x86_64                          5/102 
  Verifying  : openldap-2.4.44-25.el7_9.x86_64                            6/102 
  Verifying  : libxml2-python-2.9.1-6.el7_9.6.x86_64                      7/102 
  Verifying  : 7:device-mapper-1.02.170-6.el7_9.5.x86_64                  8/102 
  Verifying  : libxml2-2.9.1-6.el7_9.6.x86_64                             9/102 
  Verifying  : libmount-2.23.2-65.el7_9.1.x86_64                         10/102 
  Verifying  : zlib-1.2.7-21.el7_9.x86_64                                11/102 
  Verifying  : tzdata-2024a-1.el7.noarch                                 12/102 
  Verifying  : libssh2-1.8.0-4.el7_9.1.x86_64                            13/102 
  Verifying  : geoipupdate-2.5.0-2.el7.x86_64                            14/102 
  Verifying  : 1:openssl-libs-1.0.2k-26.el7_9.x86_64                     15/102 
  Verifying  : nss-pem-1.0.3-7.el7_9.1.x86_64                            16/102 
  Verifying  : util-linux-2.23.2-65.el7_9.1.x86_64                       17/102 
  Verifying  : binutils-2.27-44.base.el7_9.1.x86_64                      18/102 
  Verifying  : bash-4.2.46-35.el7_9.x86_64                               19/102 
  Verifying  : python-2.7.5-94.el7_9.x86_64                              20/102 
  Verifying  : nss-tools-3.90.0-2.el7_9.x86_64                           21/102 
  Verifying  : systemd-219-78.el7_9.9.x86_64                             22/102 
  Verifying  : 2:vim-minimal-7.4.629-8.el7_9.x86_64                      23/102 
  Verifying  : nss-sysinit-3.90.0-2.el7_9.x86_64                         24/102 
  Verifying  : cyrus-sasl-lib-2.1.26-24.el7_9.x86_64                     25/102 
  Verifying  : python-libs-2.7.5-94.el7_9.x86_64                         26/102 
  Verifying  : 7:device-mapper-libs-1.02.170-6.el7_9.5.x86_64            27/102 
  Verifying  : nss-softokn-freebl-3.90.0-6.el7_9.x86_64                  28/102 
  Verifying  : kpartx-0.4.9-136.el7_9.x86_64                             29/102 
  Verifying  : krb5-libs-1.15.1-55.el7_9.x86_64                          30/102 
  Verifying  : glibc-2.17-326.el7_9.3.x86_64                             31/102 
  Verifying  : coreutils-8.22-24.el7_9.2.x86_64                          32/102 
  Verifying  : rpm-4.11.3-48.el7_9.x86_64                                33/102 
  Verifying  : rpm-libs-4.11.3-48.el7_9.x86_64                           34/102 
  Verifying  : systemd-libs-219-78.el7_9.9.x86_64                        35/102 
  Verifying  : nss-util-3.90.0-1.el7_9.x86_64                            36/102 
  Verifying  : ca-certificates-2023.2.60_v7.0.306-72.el7_9.noarch        37/102 
  Verifying  : libuuid-2.23.2-65.el7_9.1.x86_64                          38/102 
  Verifying  : xz-libs-5.2.2-2.el7_9.x86_64                              39/102 
  Verifying  : 32:bind-license-9.11.4-26.P2.el7_9.16.noarch              40/102 
  Verifying  : diffutils-3.3-6.el7_9.x86_64                              41/102 
  Verifying  : nss-3.90.0-2.el7_9.x86_64                                 42/102 
  Verifying  : expat-2.1.0-15.el7_9.x86_64                               43/102 
  Verifying  : glib2-2.56.1-9.el7_9.x86_64                               44/102 
  Verifying  : curl-7.29.0-59.el7_9.2.x86_64                             45/102 
  Verifying  : centos-release-7-9.2009.2.el7.centos.x86_64               46/102 
  Verifying  : gzip-1.5-11.el7_9.x86_64                                  47/102 
  Verifying  : rpm-python-4.11.3-48.el7_9.x86_64                         48/102 
  Verifying  : nspr-4.35.0-1.el7_9.x86_64                                49/102 
  Verifying  : xz-5.2.2-2.el7_9.x86_64                                   50/102 
  Verifying  : rpm-build-libs-4.11.3-48.el7_9.x86_64                     51/102 
  Verifying  : rpm-4.11.3-45.el7.x86_64                                  52/102 
  Verifying  : nss-tools-3.53.1-3.el7_9.x86_64                           53/102 
  Verifying  : glibc-common-2.17-317.el7.x86_64                          54/102 
  Verifying  : ca-certificates-2020.2.41-70.0.el7_8.noarch               55/102 
  Verifying  : nss-softokn-3.53.1-6.el7_9.x86_64                         56/102 
  Verifying  : nss-util-3.53.1-1.el7_9.x86_64                            57/102 
  Verifying  : glib2-2.56.1-7.el7.x86_64                                 58/102 
  Verifying  : libssh2-1.8.0-4.el7.x86_64                                59/102 
  Verifying  : nspr-4.25.0-2.el7_9.x86_64                                60/102 
  Verifying  : nss-pem-1.0.3-7.el7.x86_64                                61/102 
  Verifying  : systemd-219-78.el7.x86_64                                 62/102 
  Verifying  : 7:device-mapper-1.02.170-6.el7.x86_64                     63/102 
  Verifying  : libblkid-2.23.2-65.el7.x86_64                             64/102 
  Verifying  : rpm-libs-4.11.3-45.el7.x86_64                             65/102 
  Verifying  : 1:openssl-libs-1.0.2k-19.el7.x86_64                       66/102 
  Verifying  : libxml2-python-2.9.1-6.el7.5.x86_64                       67/102 
  Verifying  : tzdata-2020d-2.el7.noarch                                 68/102 
  Verifying  : libuuid-2.23.2-65.el7.x86_64                              69/102 
  Verifying  : 2:vim-minimal-7.4.629-7.el7.x86_64                        70/102 
  Verifying  : geoipupdate-2.5.0-1.el7.x86_64                            71/102 
  Verifying  : coreutils-8.22-24.el7.x86_64                              72/102 
  Verifying  : nss-sysinit-3.53.1-3.el7_9.x86_64                         73/102 
  Verifying  : nss-softokn-freebl-3.53.1-6.el7_9.x86_64                  74/102 
  Verifying  : rpm-python-4.11.3-45.el7.x86_64                           75/102 
  Verifying  : libcurl-7.29.0-59.el7.x86_64                              76/102 
  Verifying  : curl-7.29.0-59.el7.x86_64                                 77/102 
  Verifying  : krb5-libs-1.15.1-50.el7.x86_64                            78/102 
  Verifying  : rpm-build-libs-4.11.3-45.el7.x86_64                       79/102 
  Verifying  : gzip-1.5-10.el7.x86_64                                    80/102 
  Verifying  : binutils-2.27-44.base.el7.x86_64                          81/102 
  Verifying  : nss-3.53.1-3.el7_9.x86_64                                 82/102 
  Verifying  : zlib-1.2.7-18.el7.x86_64                                  83/102 
  Verifying  : libxml2-2.9.1-6.el7.5.x86_64                              84/102 
  Verifying  : centos-release-7-9.2009.0.el7.centos.x86_64               85/102 
  Verifying  : systemd-libs-219-78.el7.x86_64                            86/102 
  Verifying  : diffutils-3.3-5.el7.x86_64                                87/102 
  Verifying  : openldap-2.4.44-22.el7.x86_64                             88/102 
  Verifying  : 7:device-mapper-libs-1.02.170-6.el7.x86_64                89/102 
  Verifying  : util-linux-2.23.2-65.el7.x86_64                           90/102 
  Verifying  : xz-libs-5.2.2-1.el7.x86_64                                91/102 
  Verifying  : python-2.7.5-89.el7.x86_64                                92/102 
  Verifying  : expat-2.1.0-12.el7.x86_64                                 93/102 
  Verifying  : glibc-2.17-317.el7.x86_64                                 94/102 
  Verifying  : bash-4.2.46-34.el7.x86_64                                 95/102 
  Verifying  : kpartx-0.4.9-133.el7.x86_64                               96/102 
  Verifying  : 32:bind-license-9.11.4-26.P2.el7.noarch                   97/102 
  Verifying  : python-libs-2.7.5-89.el7.x86_64                           98/102 
  Verifying  : xz-5.2.2-1.el7.x86_64                                     99/102 
  Verifying  : libsmartcols-2.23.2-65.el7.x86_64                        100/102 
  Verifying  : cyrus-sasl-lib-2.1.26-23.el7.x86_64                      101/102 
  Verifying  : libmount-2.23.2-65.el7.x86_64                            102/102 

Updated:
  bash.x86_64 0:4.2.46-35.el7_9                                                 
  bind-license.noarch 32:9.11.4-26.P2.el7_9.16                                  
  binutils.x86_64 0:2.27-44.base.el7_9.1                                        
  ca-certificates.noarch 0:2023.2.60_v7.0.306-72.el7_9                          
  centos-release.x86_64 0:7-9.2009.2.el7.centos                                 
  coreutils.x86_64 0:8.22-24.el7_9.2                                            
  curl.x86_64 0:7.29.0-59.el7_9.2                                               
  cyrus-sasl-lib.x86_64 0:2.1.26-24.el7_9                                       
  device-mapper.x86_64 7:1.02.170-6.el7_9.5                                     
  device-mapper-libs.x86_64 7:1.02.170-6.el7_9.5                                
  diffutils.x86_64 0:3.3-6.el7_9                                                
  expat.x86_64 0:2.1.0-15.el7_9                                                 
  geoipupdate.x86_64 0:2.5.0-2.el7                                              
  glib2.x86_64 0:2.56.1-9.el7_9                                                 
  glibc.x86_64 0:2.17-326.el7_9.3                                               
  glibc-common.x86_64 0:2.17-326.el7_9.3                                        
  gzip.x86_64 0:1.5-11.el7_9                                                    
  kpartx.x86_64 0:0.4.9-136.el7_9                                               
  krb5-libs.x86_64 0:1.15.1-55.el7_9                                            
  libblkid.x86_64 0:2.23.2-65.el7_9.1                                           
  libcurl.x86_64 0:7.29.0-59.el7_9.2                                            
  libmount.x86_64 0:2.23.2-65.el7_9.1                                           
  libsmartcols.x86_64 0:2.23.2-65.el7_9.1                                       
  libssh2.x86_64 0:1.8.0-4.el7_9.1                                              
  libuuid.x86_64 0:2.23.2-65.el7_9.1                                            
  libxml2.x86_64 0:2.9.1-6.el7_9.6                                              
  libxml2-python.x86_64 0:2.9.1-6.el7_9.6                                       
  nspr.x86_64 0:4.35.0-1.el7_9                                                  
  nss.x86_64 0:3.90.0-2.el7_9                                                   
  nss-pem.x86_64 0:1.0.3-7.el7_9.1                                              
  nss-softokn.x86_64 0:3.90.0-6.el7_9                                           
  nss-softokn-freebl.x86_64 0:3.90.0-6.el7_9                                    
  nss-sysinit.x86_64 0:3.90.0-2.el7_9                                           
  nss-tools.x86_64 0:3.90.0-2.el7_9                                             
  nss-util.x86_64 0:3.90.0-1.el7_9                                              
  openldap.x86_64 0:2.4.44-25.el7_9                                             
  openssl-libs.x86_64 1:1.0.2k-26.el7_9                                         
  python.x86_64 0:2.7.5-94.el7_9                                                
  python-libs.x86_64 0:2.7.5-94.el7_9                                           
  rpm.x86_64 0:4.11.3-48.el7_9                                                  
  rpm-build-libs.x86_64 0:4.11.3-48.el7_9                                       
  rpm-libs.x86_64 0:4.11.3-48.el7_9                                             
  rpm-python.x86_64 0:4.11.3-48.el7_9                                           
  systemd.x86_64 0:219-78.el7_9.9                                               
  systemd-libs.x86_64 0:219-78.el7_9.9                                          
  tzdata.noarch 0:2024a-1.el7                                                   
  util-linux.x86_64 0:2.23.2-65.el7_9.1                                         
  vim-minimal.x86_64 2:7.4.629-8.el7_9                                          
  xz.x86_64 0:5.2.2-2.el7_9                                                     
  xz-libs.x86_64 0:5.2.2-2.el7_9                                                
  zlib.x86_64 0:1.2.7-21.el7_9                                                  

Complete!
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
Resolving Dependencies
--> Running transaction check
---> Package httpd.x86_64 0:2.4.6-99.el7.centos.1 will be installed
--> Processing Dependency: httpd-tools = 2.4.6-99.el7.centos.1 for package: httpd-2.4.6-99.el7.centos.1.x86_64
--> Processing Dependency: system-logos >= 7.92.1-1 for package: httpd-2.4.6-99.el7.centos.1.x86_64
--> Processing Dependency: /etc/mime.types for package: httpd-2.4.6-99.el7.centos.1.x86_64
--> Processing Dependency: libaprutil-1.so.0()(64bit) for package: httpd-2.4.6-99.el7.centos.1.x86_64
--> Processing Dependency: libapr-1.so.0()(64bit) for package: httpd-2.4.6-99.el7.centos.1.x86_64
---> Package php.x86_64 0:5.4.16-48.el7 will be installed
--> Processing Dependency: php-common(x86-64) = 5.4.16-48.el7 for package: php-5.4.16-48.el7.x86_64
--> Processing Dependency: php-cli(x86-64) = 5.4.16-48.el7 for package: php-5.4.16-48.el7.x86_64
--> Running transaction check
---> Package apr.x86_64 0:1.4.8-7.el7 will be installed
---> Package apr-util.x86_64 0:1.5.2-6.el7_9.1 will be installed
---> Package centos-logos.noarch 0:70.0.6-3.el7.centos will be installed
---> Package httpd-tools.x86_64 0:2.4.6-99.el7.centos.1 will be installed
---> Package mailcap.noarch 0:2.1.41-2.el7 will be installed
---> Package php-cli.x86_64 0:5.4.16-48.el7 will be installed
--> Processing Dependency: libedit.so.0()(64bit) for package: php-cli-5.4.16-48.el7.x86_64
---> Package php-common.x86_64 0:5.4.16-48.el7 will be installed
--> Processing Dependency: libzip.so.2()(64bit) for package: php-common-5.4.16-48.el7.x86_64
--> Running transaction check
---> Package libedit.x86_64 0:3.0-12.20121213cvs.el7 will be installed
---> Package libzip.x86_64 0:0.10.1-8.el7 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package           Arch        Version                       Repository    Size
================================================================================
Installing:
 httpd             x86_64      2.4.6-99.el7.centos.1         updates      2.7 M
 php               x86_64      5.4.16-48.el7                 base         1.4 M
Installing for dependencies:
 apr               x86_64      1.4.8-7.el7                   base         104 k
 apr-util          x86_64      1.5.2-6.el7_9.1               updates       92 k
 centos-logos      noarch      70.0.6-3.el7.centos           base          21 M
 httpd-tools       x86_64      2.4.6-99.el7.centos.1         updates       94 k
 libedit           x86_64      3.0-12.20121213cvs.el7        base          92 k
 libzip            x86_64      0.10.1-8.el7                  base          48 k
 mailcap           noarch      2.1.41-2.el7                  base          31 k
 php-cli           x86_64      5.4.16-48.el7                 base         2.7 M
 php-common        x86_64      5.4.16-48.el7                 base         565 k

Transaction Summary
================================================================================
Install  2 Packages (+9 Dependent packages)

Total download size: 29 M
Installed size: 49 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                               35 MB/s |  29 MB  00:00     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : apr-1.4.8-7.el7.x86_64                                      1/11 
  Installing : apr-util-1.5.2-6.el7_9.1.x86_64                             2/11 
  Installing : httpd-tools-2.4.6-99.el7.centos.1.x86_64                    3/11 
  Installing : centos-logos-70.0.6-3.el7.centos.noarch                     4/11 
  Installing : libzip-0.10.1-8.el7.x86_64                                  5/11 
  Installing : php-common-5.4.16-48.el7.x86_64                             6/11 
  Installing : libedit-3.0-12.20121213cvs.el7.x86_64                       7/11 
  Installing : php-cli-5.4.16-48.el7.x86_64                                8/11 
  Installing : mailcap-2.1.41-2.el7.noarch                                 9/11 
  Installing : httpd-2.4.6-99.el7.centos.1.x86_64                         10/11 
  Installing : php-5.4.16-48.el7.x86_64                                   11/11 
  Verifying  : httpd-tools-2.4.6-99.el7.centos.1.x86_64                    1/11 
  Verifying  : mailcap-2.1.41-2.el7.noarch                                 2/11 
  Verifying  : apr-1.4.8-7.el7.x86_64                                      3/11 
  Verifying  : libedit-3.0-12.20121213cvs.el7.x86_64                       4/11 
  Verifying  : php-cli-5.4.16-48.el7.x86_64                                5/11 
  Verifying  : httpd-2.4.6-99.el7.centos.1.x86_64                          6/11 
  Verifying  : libzip-0.10.1-8.el7.x86_64                                  7/11 
  Verifying  : php-common-5.4.16-48.el7.x86_64                             8/11 
  Verifying  : php-5.4.16-48.el7.x86_64                                    9/11 
  Verifying  : apr-util-1.5.2-6.el7_9.1.x86_64                            10/11 
  Verifying  : centos-logos-70.0.6-3.el7.centos.noarch                    11/11 

Installed:
  httpd.x86_64 0:2.4.6-99.el7.centos.1        php.x86_64 0:5.4.16-48.el7       

Dependency Installed:
  apr.x86_64 0:1.4.8-7.el7                                                      
  apr-util.x86_64 0:1.5.2-6.el7_9.1                                             
  centos-logos.noarch 0:70.0.6-3.el7.centos                                     
  httpd-tools.x86_64 0:2.4.6-99.el7.centos.1                                    
  libedit.x86_64 0:3.0-12.20121213cvs.el7                                       
  libzip.x86_64 0:0.10.1-8.el7                                                  
  mailcap.noarch 0:2.1.41-2.el7                                                 
  php-cli.x86_64 0:5.4.16-48.el7                                                
  php-common.x86_64 0:5.4.16-48.el7                                             

Complete!
--> 6587022654a8
STEP 4/9: RUN rm /etc/localtime -f && ln -s /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
--> e5d21a8bafb6
STEP 5/9: COPY ["./conf/httpd.conf", "/etc/httpd/conf/httpd.conf"]
--> 6d8061996b13
STEP 6/9: COPY ["./conf/php.ini", "/etc/php.ini"]
--> e49c69c48ace
STEP 7/9: COPY ["./server/", "/var/www/html/"]
--> b9ba82ce07e9
STEP 8/9: EXPOSE 80
--> 6e9f4d540ab9
STEP 9/9: CMD /usr/sbin/httpd -DFOREGROUND
COMMIT sarcasticadmin/scale-signs:a325fba
--> 52c0ec3d39b5
Successfully tagged localhost/sarcasticadmin/scale-signs:a325fba
52c0ec3d39b57ce719f02428b866ca40d9b139d1f7134961005f5a620a896f59
```
2. I run rootless podman so I had to modify `docker-compose.yml` and set ports to `8081:80` (not captured in PR)
3. Run service then verify in web browser
```
kylerisse@watson ~/g/s/g/k/scale-signs (centos_eol)> podman-compose up
STEP 1/9: FROM centos:7
STEP 2/9: RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo &&     sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo &&     sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo &&     sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* &&     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
--> Using cache b74e2524b310aa294454d23533605a0ff774cc8c2ec9fd26f970ae7f035e33c0
--> b74e2524b310
STEP 3/9: RUN yum update -y && yum install -y httpd php
--> Using cache 6587022654a88f46f1a936f32cbba79823349c470000410244310a0ed42216e5
--> 6587022654a8
STEP 4/9: RUN rm /etc/localtime -f && ln -s /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
--> Using cache e5d21a8bafb62f26d2982ab87972458b5ecee2fdc2673e858639e574320f358c
--> e5d21a8bafb6
STEP 5/9: COPY ["./conf/httpd.conf", "/etc/httpd/conf/httpd.conf"]
--> Using cache 6d8061996b1311a60c0f95b15ef10f6c8cd2e80e9d6ab5aeff076540c10126a3
--> 6d8061996b13
STEP 6/9: COPY ["./conf/php.ini", "/etc/php.ini"]
--> Using cache e49c69c48aceb93de5daea801ab27c022ecf9308fc90491319d4ffb70e82ce44
--> e49c69c48ace
STEP 7/9: COPY ["./server/", "/var/www/html/"]
--> Using cache b9ba82ce07e93aee52fa5d88c4ef94678ed35ad24d97906588cae99658fb273d
--> b9ba82ce07e9
STEP 8/9: EXPOSE 80
--> Using cache 6e9f4d540ab9bcc80033fb4ae0d95cb7fcdc197b76a8dc6c5b41cc39fd112add
--> 6e9f4d540ab9
STEP 9/9: CMD /usr/sbin/httpd -DFOREGROUND
--> Using cache 52c0ec3d39b57ce719f02428b866ca40d9b139d1f7134961005f5a620a896f59
COMMIT signs
--> 52c0ec3d39b5
Successfully tagged localhost/signs:latest
Successfully tagged localhost/sarcasticadmin/scale-signs:a325fba
52c0ec3d39b57ce719f02428b866ca40d9b139d1f7134961005f5a620a896f59
Error: adding pod to state: name "pod_scale-signs" is in use: pod already exists
2592f7104d6f094c37646e154a93177af6dab8a31612da3019e0e23193079aad
[signs] | [Sat Nov 30 16:13:03.835446 2024] [env:warn] [pid 1] AH01506: PassEnv variable TWITTER_OAUTH_ACCESS_TOKEN was undefined
[signs] | [Sat Nov 30 16:13:03.835512 2024] [env:warn] [pid 1] AH01506: PassEnv variable TWITTER_OAUTH_ACCESS_TOKEN_SECRET was undefined
[signs] | [Sat Nov 30 16:13:03.835513 2024] [env:warn] [pid 1] AH01506: PassEnv variable TWITTER_OAUTH_CONSUMER_KEY was undefined
[signs] | [Sat Nov 30 16:13:03.835514 2024] [env:warn] [pid 1] AH01506: PassEnv variable TWITTER_OAUTH_CONSUMER_SECRET was undefined
[signs] | [Sat Nov 30 16:13:03.850676 2024] [suexec:notice] [pid 1] AH01232: suEXEC mechanism enabled (wrapper: /usr/sbin/suexec)
[signs] | [Sat Nov 30 16:13:03.863580 2024] [env:warn] [pid 1] AH01506: PassEnv variable TWITTER_OAUTH_ACCESS_TOKEN was undefined
[signs] | [Sat Nov 30 16:13:03.863584 2024] [env:warn] [pid 1] AH01506: PassEnv variable TWITTER_OAUTH_ACCESS_TOKEN_SECRET was undefined
[signs] | [Sat Nov 30 16:13:03.863586 2024] [env:warn] [pid 1] AH01506: PassEnv variable TWITTER_OAUTH_CONSUMER_KEY was undefined
[signs] | [Sat Nov 30 16:13:03.863587 2024] [env:warn] [pid 1] AH01506: PassEnv variable TWITTER_OAUTH_CONSUMER_SECRET was undefined
[signs] | [Sat Nov 30 16:13:03.868923 2024] [lbmethod_heartbeat:notice] [pid 1] AH02282: No slotmem from mod_heartmonitor
[signs] | [Sat Nov 30 16:13:03.878084 2024] [mpm_prefork:notice] [pid 1] AH00163: Apache/2.4.6 (CentOS) PHP/5.4.16 configured -- resuming normal operations
[signs] | [Sat Nov 30 16:13:03.878096 2024] [core:notice] [pid 1] AH00094: Command line: '/usr/sbin/httpd -D FOREGROUND'
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET / HTTP/1.1" 200 6619
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /sponsors.php?group=two&_=1733011992616 HTTP/1.1" 200 1813
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /sponsors.php?group=one&_=1733011992615 HTTP/1.1" 200 1914
[signs] | [30-Nov-2024 16:13:12 America/Los_Angeles] PHP Notice:  Undefined index: TWITTER_OAUTH_ACCESS_TOKEN in /var/www/html/twitter.php on line 15
[signs] | [30-Nov-2024 16:13:12 America/Los_Angeles] PHP Notice:  Undefined index: TWITTER_OAUTH_ACCESS_TOKEN_SECRET in /var/www/html/twitter.php on line 16
[signs] | [30-Nov-2024 16:13:12 America/Los_Angeles] PHP Notice:  Undefined index: TWITTER_OAUTH_CONSUMER_KEY in /var/www/html/twitter.php on line 17
[signs] | [30-Nov-2024 16:13:12 America/Los_Angeles] PHP Notice:  Undefined index: TWITTER_OAUTH_CONSUMER_SECRET in /var/www/html/twitter.php on line 18
[signs] | [30-Nov-2024 16:13:12 America/Los_Angeles] PHP Fatal error:  Uncaught exception 'Exception' with message 'Make sure you are passing in the correct parameters' in /var/www/html/TwitterAPIExchange.php:84
[signs] | Stack trace:
[signs] | #0 /var/www/html/twitter.php(36): TwitterAPIExchange->__construct(Array)
[signs] | #1 /var/www/html/twitter.php(107): search_twitter()
[signs] | #2 {main}
[signs] |   thrown in /var/www/html/TwitterAPIExchange.php on line 84
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /twitter.php?_=1733011992617 HTTP/1.1" 200 1015
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /js/jquery-1.10.2.min.js?_=1733011992618 HTTP/1.1" 200 93100
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /js/jquery.marquee.js?_=1733011992619 HTTP/1.1" 200 7381
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /bootstrap/js/bootstrap.min.js?_=1733011992620 HTTP/1.1" 200 27822
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /images/sponsors/freebsd.png HTTP/1.1" 200 14287
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /images/sponsors/opensource_jobhub.png HTTP/1.1" 200 11965
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /js/jquery-1.10.2.min.js?_=1733011992621 HTTP/1.1" 200 93100
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /images/sponsors/honeycomb.png HTTP/1.1" 200 25412
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /images/sponsors/netknights.png HTTP/1.1" 200 11414
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /images/sponsors/flox.png HTTP/1.1" 200 17059
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /js/jquery.marquee.js?_=1733011992622 HTTP/1.1" 200 7381
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /bootstrap/js/bootstrap.min.js?_=1733011992623 HTTP/1.1" 200 27822
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /images/sponsors/pingcap.png HTTP/1.1" 200 6648
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /images/sponsors/commitgo.png HTTP/1.1" 200 5546
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:12 -0800] "GET /scroll.php?year=&month=&day=&hour=&minute=&_=1733011992614 HTTP/1.1" 200 14244
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:13 -0800] "GET /js/jquery-1.10.2.min.js?_=1733011992624 HTTP/1.1" 200 93100
[signs] | 10.89.0.18 - - [30/Nov/2024:16:13:13 -0800] "GET /bootstrap/js/bootstrap.min.js?_=1733011992625 HTTP/1.1" 200 27822
[signs] | ::1 - - [30/Nov/2024:16:13:19 -0800] "OPTIONS * HTTP/1.0" 200 -
[signs] | ::1 - - [30/Nov/2024:16:13:20 -0800] "OPTIONS * HTTP/1.0" 200 -
```
