### PR TITLE
docs: go-signs.org -> scalenoc.org

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Kyle Risse
+Copyright (c) 2026 Southern California Linux Expo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 `scale-signs` is a modern Go-based service designed to power the digital signage system for the Southern California Linux Expo (SCaLE). It is specifically built to run as a single binary on Raspberry Pi devices distributed throughout the venue. Each Pi serves as a standalone digital sign displaying conference schedules, speaker information, and event logistics.
 
+This project is a continuation of the original [PHP app](https://github.com/socallinuxexpo/scale-signs/tree/8f6ed2f4bdd10f34e123db1d557da0a7fee4f707) which was a mainstay of SCaLE through 22x (2025).
+
 ## Demo
 
-A [DEMO](https://demo.go-signs.org) of this application is available online. It leverages the [SCaLE Simulator](./docs/SIMULATOR.md) and supports [time override](#time-override) URL parameters for any scale between 13x and 22x in addition to a simulated "current" SCaLE that is always active.
+A [DEMO](https://signs.scalenoc.org) of this application is available online. It leverages the [SCaLE Simulator](./docs/SIMULATOR.md) and supports [time override](#time-override) URL parameters for any scale between 13x and 22x in addition to a simulated "current" SCaLE that is always active.
 
 > Please note that `scale-signs` is currently meant to be displayed at 1080p only. Responsive design to support 720p -> 4k is planned for a later release.
 
@@ -39,7 +41,7 @@ During development, you will often need to test how the schedule display behaves
 1. Open your development instance in a browser
 2. Add URL parameters to simulate a specific time:
    ```
-   https://demo.go-signs.org/?year=2025&month=3&day=6&hour=13&minute=53
+   https://signs.scalenoc.org/?year=2026&month=3&day=7&hour=14&minute=24
    ```
 3. The application will use this simulated time instead of the actual system time
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -11,8 +11,8 @@ This project leverages [Scaled Trunk-Based Development](https://trunkbaseddevelo
 To be performed by maintainers
 
 1. Create a `release/x.x` branch off of `master`
-1. Create a version commit directly to the release branch. (Example for `0.1.0` from [release/0.1](https://github.com/socallinuxexpo/scale-signs/commit/7415c17d05c03e9fb128b65b9bd0ad10197fcd22) branch). These commits exist to version the nix package and corresponding react application and corresponding NPM hash.
-1. Create a tag against the release branch. (Example `0.1.0`)
+1. Create a version commit directly to the release branch. (Example for `0.2.0` from [release/0.2](https://github.com/socallinuxexpo/scale-signs/commit/b457d01efa37a61d573eeb1a4225d5df4291b878) branch). These commits exist to version the nix package and corresponding react application and corresponding NPM hash.
+1. Create a tag against the release branch. (Example `0.2.0`)
 1. Run `nix run .#scale-signs-ci-release`.
 1. Upload all artifacts from `result/` to the GitHub releases page.
 
@@ -20,6 +20,6 @@ To be performed by maintainers
 
 1. Develop the fix as normal and merge via PR to the `master` branch.
 1. Cherry pick the corresponding fix commits to the `release/x.x` branch.
-1. Create a version commit directly to the release branch. (Example `0.1.1`)
-1. Create a tag against the release branch. (Example `0.1.1`)
+1. Create a version commit directly to the release branch. (Example `0.2.1`)
+1. Create a tag against the release branch. (Example `0.2.1`)
 1. Upload all artifacts from `result/` to the GitHub releases page.

--- a/docs/SIMULATOR.md
+++ b/docs/SIMULATOR.md
@@ -66,17 +66,17 @@ When first run, the simulator will:
 
 ## API Endpoints
 
-| Endpoint      | Method | Description                                                                     |
-| ------------- | ------ | ------------------------------------------------------------------------------- |
-| `/`           | GET    | Status check endpoint returning status and current time                         |
-| `/sign.json`  | GET    | Returns the simulation as JSON (main Drupal endpoint for the scale-signs backend)  |
-| `/archive/$x` | GET    | Returns any schedule from a specific scale, where `$x` is ex: `13x`, `23x`, etc |
+| Endpoint      | Method | Description                                                                       |
+| ------------- | ------ | --------------------------------------------------------------------------------- |
+| `/`           | GET    | Status check endpoint returning status and current time                           |
+| `/sign.json`  | GET    | Returns the simulation as JSON (main Drupal endpoint for the scale-signs backend) |
+| `/archive/$x` | GET    | Returns any schedule from a specific scale, where `$x` is ex: `13x`, `23x`, etc   |
 
 ## Use Cases
 
 ### Demo Site
 
-The `scale-signs` [DEMO](https://demo.go-signs.org) site leverages an always running instance of the Simulator's [JSON endpoint](https://simulator.go-signs.org/sign.json).
+The `scale-signs` [DEMO](https://signs.scalenoc.org) site leverages an always running instance of the Simulator's [JSON endpoint](https://simulator.scalenoc.org/sign.json).
 
 ### Local Development
 


### PR DESCRIPTION
As noted in https://github.com/socallinuxexpo/scale-network/issues/746

## Description of PR

Documentation update only. I'd like to retire `go-signs.org` in favor of the 

## Previous Behavior

- No attribution to original PHP code
- Docs reflected `go-signs.org` domain, not `scalenoc.org` domain
- Release doc example commit did not exist

## New Behavior

- Attribution to original PHP code in readme
- Docs reflect `scalenoc.org` only
- Release doc example links to real `0.2.0` release commit

## Tests

Read docs, follow links.
